### PR TITLE
Refactor: Remove cardId from onPlay and onDeactivate effects

### DIFF
--- a/app/src/main/java/com/sq/thed_ck_licker/ecs/components/EffectComponent.kt
+++ b/app/src/main/java/com/sq/thed_ck_licker/ecs/components/EffectComponent.kt
@@ -12,13 +12,13 @@ data class EffectComponent(
     val onDeath: (Int) -> Unit = {},
     val onSpawn: (Int) -> Unit = {},
     val onTurnStart: (Int) -> Unit = {},
-    val onPlay: (Int, Int) -> Unit = { _, _ -> },
-    val onDeactivate: (Int, Int) -> Unit = { _, _ -> },
+    val onPlay: (Int) -> Unit = { _ -> },
+    val onDeactivate: (Int) -> Unit = { _ -> },
 ) {
     fun combineEffectComponents(other: EffectComponent): EffectComponent {
-        val onPlay: (Int, Int) -> Unit = { targetId, latestCard ->
-            this.onPlay.invoke(targetId, latestCard)
-            other.onPlay.invoke(targetId, latestCard)
+        val onPlay: (Int) -> Unit = { targetId ->
+            this.onPlay.invoke(targetId)
+            other.onPlay.invoke(targetId)
         }
         val onDeath: (Int) -> Unit = {
             this.onDeath.invoke(it)
@@ -32,9 +32,9 @@ data class EffectComponent(
             this.onTurnStart.invoke(it)
             other.onTurnStart.invoke(it)
         }
-        val onDeactivate: (Int, Int) -> Unit = { targetId, latestCard ->
-            this.onDeactivate.invoke(targetId, latestCard)
-            other.onDeactivate.invoke(targetId, latestCard)
+        val onDeactivate: (Int) -> Unit = { targetId ->
+            this.onDeactivate.invoke(targetId)
+            other.onDeactivate.invoke(targetId)
         }
         return EffectComponent(
             onPlay = onPlay,
@@ -46,22 +46,19 @@ data class EffectComponent(
     }
 
     fun shuffleToNew(): EffectComponent {
-        val ekat = mutableListOf<(Int) -> Unit>()
-        ekat.add(onDeath)
-        ekat.add(onSpawn)
-        ekat.add(onTurnStart)
-
-        // TODO: This is way more fun when these two can be combined into one.
-        val tokat = mutableListOf<(Int, Int) -> Unit>()
-        tokat.add(onPlay)
-        tokat.add(onDeactivate)
+        val effectHandlers = mutableListOf<(Int) -> Unit>()
+        effectHandlers.add(onDeath)
+        effectHandlers.add(onSpawn)
+        effectHandlers.add(onTurnStart)
+        effectHandlers.add(onPlay)
+        effectHandlers.add(onDeactivate)
 
         return EffectComponent(
-            onDeath = ekat.removeAt(random.nextInt(ekat.size)),
-            onSpawn = ekat.removeAt(random.nextInt(ekat.size)),
-            onTurnStart = ekat.removeAt(random.nextInt(ekat.size)),
-            onPlay = tokat.removeAt(random.nextInt(tokat.size)),
-            onDeactivate = tokat.removeAt(random.nextInt(tokat.size))
+            onDeath = effectHandlers.removeAt(random.nextInt(effectHandlers.size)),
+            onSpawn = effectHandlers.removeAt(random.nextInt(effectHandlers.size)),
+            onTurnStart = effectHandlers.removeAt(random.nextInt(effectHandlers.size)),
+            onPlay = effectHandlers.removeAt(random.nextInt(effectHandlers.size)),
+            onDeactivate = effectHandlers.removeAt(random.nextInt(effectHandlers.size))
         )
     }
 }

--- a/app/src/main/java/com/sq/thed_ck_licker/ecs/components/misc/LatestCardComponent.kt
+++ b/app/src/main/java/com/sq/thed_ck_licker/ecs/components/misc/LatestCardComponent.kt
@@ -1,0 +1,5 @@
+package com.sq.thed_ck_licker.ecs.components.misc
+
+import com.sq.thed_ck_licker.ecs.managers.EntityId
+
+data class LatestCardComponent(var latestCard: EntityId)

--- a/app/src/main/java/com/sq/thed_ck_licker/ecs/systems/CardPullingSystem.kt
+++ b/app/src/main/java/com/sq/thed_ck_licker/ecs/systems/CardPullingSystem.kt
@@ -19,10 +19,7 @@ class CardPullingSystem @Inject constructor(private val cardsSystem: CardsSystem
     ) {
 
         try {
-            (latestCard.intValue get EffectComponent::class).onDeactivate.invoke(
-                getPlayerID(),
-                latestCard.intValue
-            )
+            (latestCard.intValue get EffectComponent::class).onDeactivate.invoke(getPlayerID())
         } catch (_: IllegalStateException) {
             Log.i(
                 "pullNewCardSystem",

--- a/app/src/main/java/com/sq/thed_ck_licker/ecs/systems/cardSystems/CardBuilderSystem.kt
+++ b/app/src/main/java/com/sq/thed_ck_licker/ecs/systems/cardSystems/CardBuilderSystem.kt
@@ -31,8 +31,8 @@ class CardBuilderSystem @Inject constructor(private val componentManager: Compon
     var description: String = ""
     var name: String = ""
     var tags: List<CardTag> = listOf(CardTag.CARD)
-    var onCardPlay: (Int, Int) -> Unit = { _, _ -> }
-    var onCardDeactivate: (Int, Int) -> Unit = { _, _ -> }
+    var onCardPlay: (Int) -> Unit = { _ -> }
+    var onCardDeactivate: (Int) -> Unit = { _ -> }
 
     private fun initCards(): List<Int> {
         val cardIds: MutableList<Int> = mutableListOf()
@@ -77,7 +77,7 @@ class CardBuilderSystem @Inject constructor(private val componentManager: Compon
                 }
             }
 
-            val onActivation = { targetId: Int, _: Int ->
+            val onActivation = { targetId: Int ->
                 val scoreComponent = targetId get ScoreComponent::class
                 Log.i("Time Bound Activation", "Activation number: ${selfCounter.getActivations()}")
                 if (selfCounter.getActivations() == 2) {

--- a/app/src/main/java/com/sq/thed_ck_licker/ecs/systems/cardSystems/CardsSystem.kt
+++ b/app/src/main/java/com/sq/thed_ck_licker/ecs/systems/cardSystems/CardsSystem.kt
@@ -8,6 +8,7 @@ import com.sq.thed_ck_licker.ecs.components.EffectComponent
 import com.sq.thed_ck_licker.ecs.components.EffectStackComponent
 import com.sq.thed_ck_licker.ecs.components.MultiplierComponent
 import com.sq.thed_ck_licker.ecs.components.misc.HealthComponent
+import com.sq.thed_ck_licker.ecs.components.misc.LatestCardComponent
 import com.sq.thed_ck_licker.ecs.components.misc.ScoreComponent
 import com.sq.thed_ck_licker.ecs.managers.ComponentManager.Companion.componentManager
 import com.sq.thed_ck_licker.ecs.managers.EntityManager.getPlayerID
@@ -59,6 +60,9 @@ class CardsSystem @Inject constructor(private var multiSystem: MultiplierSystem)
     private fun activateCard(latestCard: MutableIntState, playerCardCount: MutableIntState) {
         playerCardCount.intValue += 1
         val latestCardId = latestCard.intValue
+        val latestCardComponent = (getPlayerID() get LatestCardComponent::class)
+        latestCardComponent.latestCard = latestCardId
+
         var latestCardHp: HealthComponent? = null
 
         try {
@@ -73,7 +77,7 @@ class CardsSystem @Inject constructor(private var multiSystem: MultiplierSystem)
 
 
         try {
-            (latestCardId get EffectComponent::class).onPlay.invoke(getPlayerID(), latestCardId)
+            (latestCardId get EffectComponent::class).onPlay.invoke(getPlayerID())
         } catch (_: IllegalStateException) {
             Log.i(
                 "CardsSystem",

--- a/app/src/main/java/com/sq/thed_ck_licker/ecs/systems/characterSystems/PlayerSystem.kt
+++ b/app/src/main/java/com/sq/thed_ck_licker/ecs/systems/characterSystems/PlayerSystem.kt
@@ -6,6 +6,7 @@ import com.sq.thed_ck_licker.ecs.components.DrawDeckComponent
 import com.sq.thed_ck_licker.ecs.components.EffectStackComponent
 import com.sq.thed_ck_licker.ecs.components.MultiplierComponent
 import com.sq.thed_ck_licker.ecs.components.misc.HealthComponent
+import com.sq.thed_ck_licker.ecs.components.misc.LatestCardComponent
 import com.sq.thed_ck_licker.ecs.components.misc.ScoreComponent
 import com.sq.thed_ck_licker.ecs.components.misc.TickComponent
 import com.sq.thed_ck_licker.ecs.managers.EntityManager.getPlayerID
@@ -30,6 +31,8 @@ class PlayerSystem @Inject constructor(private val cardCreationSystem: CardCreat
         getPlayerID() add EffectStackComponent()
         getPlayerID() add DiscardDeckComponent(mutableListOf<Int>())
         getPlayerID() add MultiplierComponent()
+        getPlayerID() add LatestCardComponent(-100)
+
         if (areRealTimeThingsEnabled.value) {
             getPlayerID() add TickComponent(tickAction = healthTicker())
         }

--- a/app/src/main/java/com/sq/thed_ck_licker/ecs/systems/helperSystems/onDiscardSystem.kt
+++ b/app/src/main/java/com/sq/thed_ck_licker/ecs/systems/helperSystems/onDiscardSystem.kt
@@ -1,10 +1,10 @@
 package com.sq.thed_ck_licker.ecs.systems.helperSystems
 
 import android.util.Log
-import com.sq.thed_ck_licker.ecs.managers.ComponentManager
 import com.sq.thed_ck_licker.ecs.components.DiscardDeckComponent
 import com.sq.thed_ck_licker.ecs.components.EffectComponent
 import com.sq.thed_ck_licker.ecs.components.EffectStackComponent
+import com.sq.thed_ck_licker.ecs.managers.ComponentManager
 import com.sq.thed_ck_licker.ecs.managers.get
 
 fun onDiscardSystem(componentManager: ComponentManager = ComponentManager.componentManager) {
@@ -15,7 +15,7 @@ fun onDiscardSystem(componentManager: ComponentManager = ComponentManager.compon
         val effectStack = effectTarget.value as EffectStackComponent
         for (effectEntity in effectStack.getEffectEntities()) {
             val effect = effectEntity get EffectComponent::class
-            effect.onDeactivate(effectTarget.key, effectEntity)
+//            effect.onDeactivate(effectTarget.key, effectEntity)
         }
     }
 }
@@ -26,7 +26,7 @@ fun discardSystem(
 ) {
     try {
         val cardEffects = cardId get EffectComponent::class
-        cardEffects.onDeactivate(ownerId, cardId)
+        cardEffects.onDeactivate(ownerId)
     } catch (_: IllegalStateException) {
         Log.i("discardSystem", "No deactivation effect found for card $cardId")
     }


### PR DESCRIPTION
The cardId is now accessed via the LatestCardComponent on the player entity. This change simplifies the function signatures for onPlay and onDeactivate effects. A new LatestCardComponent has been added to the player entity to store the ID of the most recently played card.

Oh boy I wish there was tests for everything.
Or that I had energy and time to implement them...