### PR TITLE
Adjust SonarQube workflow triggers

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,12 +1,10 @@
 name: Sonarqube Test Quality Analysis
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'lambdas/test/**'
+    branches: [ "main" ]
   pull_request:
     types: [opened, synchronize, reopened]
+    branches: [ "main" ]
 jobs:
   sonarqubeScan1:
     name: SonarQubeScan1


### PR DESCRIPTION
- Trigger analysis on push and pull requests to the `main` branch.
- Removed path-based trigger for pushes to `lambdas/test/**`.

Sonar should now trigger more easily in main.